### PR TITLE
Optimized gameobject & fixed SceneGraph problems

### DIFF
--- a/LeapEngine/Components/Component.cpp
+++ b/LeapEngine/Components/Component.cpp
@@ -4,7 +4,12 @@
 
 void leap::Component::Destroy()
 {
-	m_IsMarkedDead = true;
+	m_StateFlags |= static_cast<unsigned char>(StateFlags::IsMarkedAsDead);
+}
+
+bool leap::Component::IsMarkedAsDead() const
+{
+	return m_StateFlags & static_cast<unsigned char>(StateFlags::IsMarkedAsDead);
 }
 
 void leap::Component::SetActive(bool isActive)
@@ -12,12 +17,15 @@ void leap::Component::SetActive(bool isActive)
 	// Set the next active state
 	// The new active state will be handled at the end of the frame
 	//		(e.g. call OnEnable/OnDisable)
-	m_NextIsActiveLocal = isActive;
+	if (isActive)
+		m_StateFlags |= static_cast<unsigned char>(StateFlags::IsActiveLocalNextFrame);
+	else
+		m_StateFlags &= ~static_cast<unsigned char>(StateFlags::IsActiveLocalNextFrame);
 }
 
 bool leap::Component::IsActive() const
 {
-	return m_IsActiveLocal && m_pOwner->IsActive();
+	return IsActiveWorld();
 }
 
 void leap::Component::SetOwner(GameObject* pOwner)
@@ -28,35 +36,104 @@ void leap::Component::SetOwner(GameObject* pOwner)
 void leap::Component::ChangeActiveState()
 {
 	// Cache the previous world state
-	m_PrevIsActiveWorld = m_IsActiveWorld;
+	SetPreviousActiveWorld(IsActiveWorld());
 
-	if (m_NextIsActiveLocal != m_IsActiveLocal)
+	// Retrieve the local states
+	const bool isActiveLocal{ IsActiveLocal() };
+	const bool isActiveLocalNextFrame{ IsActiveLocalNextFrame() };
+
+	// Only change the local state if necessary
+	if (isActiveLocalNextFrame != isActiveLocal)
 	{
 		// Set the new local state
-		m_IsActiveLocal = m_NextIsActiveLocal;
+		SetActiveLocal(isActiveLocalNextFrame);
 	}
 
 	// Update the world state of this component
-	m_IsActiveWorld = m_IsActiveLocal && m_pOwner->IsActive();
+	SetActiveWorld(isActiveLocal && m_pOwner->IsActive());
 }
 
 void leap::Component::TryCallStart()
 {
 	// Don't call start twice
-	if (m_HasStarted) return;
+	if (HasStarted()) return;
 	
 	// Don't call start if the component is not active
-	if (!m_IsActiveWorld) return;
+	if (!IsActiveWorld()) return;
 
-	m_HasStarted = true;
+	// Active the started bit flag
+	m_StateFlags |= static_cast<unsigned char>(StateFlags::HasStarted);
+
 	Start();
 }
 
 void leap::Component::TryCallEnableAndDisable()
 {
-	// Don't call a method if the worldstate hasn't changed
-	if (m_PrevIsActiveWorld == m_IsActiveWorld) return;
+	const bool isActiveWorld{ IsActiveWorld() };
 
-	if (m_IsActiveWorld) OnEnable();
+	// Don't call a method if the worldstate hasn't changed
+	if (WasActiveWorldPreviousFrame() == isActiveWorld) return;
+
+	// Call the appropriate method
+	if (isActiveWorld) OnEnable();
 	else OnDisable();
+}
+
+bool leap::Component::IsActiveLocalNextFrame() const
+{
+	return m_StateFlags & static_cast<unsigned char>(StateFlags::IsActiveLocalNextFrame);
+}
+
+bool leap::Component::IsActiveLocal() const
+{
+	return m_StateFlags & static_cast<unsigned char>(StateFlags::IsActiveLocal);
+}
+
+void leap::Component::SetActiveLocal(bool isActive)
+{
+	if (isActive)
+		m_StateFlags |= static_cast<unsigned char>(StateFlags::IsActiveLocal);
+	else
+		m_StateFlags &= ~static_cast<unsigned char>(StateFlags::IsActiveLocal);
+}
+
+bool leap::Component::IsActiveWorld() const
+{
+	return m_StateFlags & static_cast<unsigned char>(StateFlags::IsActiveWorld);
+}
+
+void leap::Component::SetActiveWorld(bool isActive)
+{
+	if (isActive)
+		m_StateFlags |= static_cast<unsigned char>(StateFlags::IsActiveWorld);
+	else
+		m_StateFlags &= ~static_cast<unsigned char>(StateFlags::IsActiveWorld);
+}
+
+bool leap::Component::WasActiveWorldPreviousFrame() const
+{
+	return m_StateFlags & static_cast<unsigned char>(StateFlags::WasActiveWorldPreviousFrame);
+}
+
+void leap::Component::SetPreviousActiveWorld(bool isActive)
+{
+	if (isActive)
+		m_StateFlags |= static_cast<unsigned char>(StateFlags::WasActiveWorldPreviousFrame);
+	else
+		m_StateFlags &= ~static_cast<unsigned char>(StateFlags::WasActiveWorldPreviousFrame);
+}
+
+bool leap::Component::HasStarted() const
+{
+	return m_StateFlags & static_cast<unsigned char>(StateFlags::HasStarted);
+}
+
+bool leap::Component::IsInitialized() const
+{
+	return m_StateFlags & static_cast<unsigned char>(StateFlags::IsInitialized);
+}
+
+void leap::Component::Initialize()
+{
+	m_StateFlags |= static_cast<unsigned char>(StateFlags::IsInitialized);
 }

--- a/LeapEngine/Components/Component.cpp
+++ b/LeapEngine/Components/Component.cpp
@@ -39,18 +39,17 @@ void leap::Component::ChangeActiveState()
 	SetPreviousActiveWorld(IsActiveWorld());
 
 	// Retrieve the local states
-	const bool isActiveLocal{ IsActiveLocal() };
 	const bool isActiveLocalNextFrame{ IsActiveLocalNextFrame() };
 
 	// Only change the local state if necessary
-	if (isActiveLocalNextFrame != isActiveLocal)
+	if (isActiveLocalNextFrame != IsActiveLocal())
 	{
 		// Set the new local state
 		SetActiveLocal(isActiveLocalNextFrame);
 	}
 
 	// Update the world state of this component
-	SetActiveWorld(isActiveLocal && m_pOwner->IsActive());
+	SetActiveWorld(IsActiveLocal() && m_pOwner->IsActive());
 }
 
 void leap::Component::TryCallStart()

--- a/LeapEngine/Components/Component.h
+++ b/LeapEngine/Components/Component.h
@@ -24,16 +24,16 @@ namespace leap
 		bool IsActive() const;
 
 	protected:
-		virtual void Awake() {};
-		virtual void Start() {};
-		virtual void OnEnable() {};
-		virtual void OnDisable() {};
-		virtual void Update() {};
-		virtual void FixedUpdate() {};
-		virtual void LateUpdate() {};
-		virtual void Render() {};
-		virtual void OnGUI() {};
-		virtual void OnDestroy() {};
+		virtual void Awake() {}
+		virtual void Start() {}
+		virtual void OnEnable() {}
+		virtual void OnDisable() {}
+		virtual void Update() {}
+		virtual void FixedUpdate() {}
+		virtual void LateUpdate() {}
+		virtual void Render() {}
+		virtual void OnGUI() {}
+		virtual void OnDestroy() {}
 
 	private:
 		friend GameObject;

--- a/LeapEngine/Components/Component.h
+++ b/LeapEngine/Components/Component.h
@@ -18,7 +18,7 @@ namespace leap
 		GameObject* GetGameObject() const { return m_pOwner; }
 
 		void Destroy();
-		bool IsMarkedAsDead() const { return m_IsMarkedDead; };
+		bool IsMarkedAsDead() const;
 
 		void SetActive(bool isActive);
 		bool IsActive() const;
@@ -44,15 +44,34 @@ namespace leap
 		void TryCallStart();
 		void TryCallEnableAndDisable();
 
+		/// <summary>
+		/// These functions are internally used to 
+		/// change and check values of the m_StateFlags bitmask
+		/// </summary>
+		bool IsActiveLocalNextFrame() const;
+		bool IsActiveLocal() const;
+		void SetActiveLocal(bool isActive);
+		bool IsActiveWorld() const;
+		void SetActiveWorld(bool isActive);
+		bool WasActiveWorldPreviousFrame() const;
+		void SetPreviousActiveWorld(bool isActive);
+		bool HasStarted() const;
+		bool IsInitialized() const;
+		void Initialize();
+
+		enum class StateFlags : char
+		{
+			IsActiveLocalNextFrame		= 1 << 0,
+			IsActiveLocal				= 1 << 1,
+			WasActiveWorldPreviousFrame = 1 << 2,
+			IsActiveWorld				= 1 << 3,
+			IsInitialized				= 1 << 4,
+			HasStarted					= 1 << 5,
+			IsMarkedAsDead				= 1 << 6
+		};
+
+		unsigned char m_StateFlags{ static_cast<unsigned char>(StateFlags::IsActiveLocalNextFrame) };
+
 		GameObject* m_pOwner{};
-
-		bool m_NextIsActiveLocal{ true };
-		bool m_IsActiveLocal{ false };
-
-		bool m_PrevIsActiveWorld{ false };
-		bool m_IsActiveWorld{ false };
-
-		bool m_HasStarted{};
-		bool m_IsMarkedDead{};
 	};
 }

--- a/LeapEngine/GameContext/Timer.cpp
+++ b/LeapEngine/GameContext/Timer.cpp
@@ -2,9 +2,14 @@
 
 #include <chrono>
 
+leap::Timer::Timer()
+{
+	m_End = std::chrono::high_resolution_clock::now();
+}
+
 void leap::Timer::Update()
 {
-	const auto currentTime = std::chrono::high_resolution_clock::now();
+	const auto currentTime{ std::chrono::high_resolution_clock::now() };
 	m_DeltaTime = std::chrono::duration<float>(currentTime - m_End).count();
 	m_End = currentTime;
 }

--- a/LeapEngine/GameContext/Timer.h
+++ b/LeapEngine/GameContext/Timer.h
@@ -7,7 +7,7 @@ namespace leap
 	class Timer final
 	{
 	public:
-		Timer() = default;
+		Timer();
 		~Timer() = default;
 		Timer(const Timer& other) = delete;
 		Timer(Timer&& other) = delete;
@@ -24,6 +24,6 @@ namespace leap
 
 		float m_FixedTime{ 0.02f };
 		float m_DeltaTime{};
-		std::chrono::time_point<std::chrono::steady_clock> m_End;
+		std::chrono::time_point<std::chrono::steady_clock> m_End{};
 	};
 }

--- a/LeapEngine/SceneGraph/GameObject.cpp
+++ b/LeapEngine/SceneGraph/GameObject.cpp
@@ -6,7 +6,7 @@
 
 #include "SceneManager.h"
 
-leap::GameObject::GameObject(const std::string& name)
+leap::GameObject::GameObject(const char* name)
 	: m_Name{ name }
 {
 	m_pTransform = AddComponent<Transform>();
@@ -41,7 +41,7 @@ void leap::GameObject::SetParent(GameObject* pParent)
 	m_pParent = pParent;
 }
 
-leap::GameObject* leap::GameObject::CreateChild(const std::string& name)
+leap::GameObject* leap::GameObject::CreateChild(const char* name)
 {
 	// Create a new gameobject
 	auto pGameObject{ std::make_unique<GameObject>(name) };

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -77,7 +77,6 @@ namespace leap
 		void OnFrameStart();
 		void MoveNewObjectsAndComponents();
 		void CallAwake() const;
-		void OnFrameStartCleanup();
 		void ChangeActiveState();
 		void SetWorldState(bool isActive);
 		void CallStart() const;
@@ -104,10 +103,10 @@ namespace leap
 
 		enum class StateFlags : char
 		{
-			IsActiveLocalNextFrame = 1,
-			IsActiveLocal = 2,
-			IsActiveWorld = 4,
-			IsMarkedAsDead = 8
+			IsActiveLocalNextFrame	= 1 << 0,
+			IsActiveLocal			= 1 << 1,
+			IsActiveWorld			= 1 << 2,
+			IsMarkedAsDead			= 1 << 3
 		};
 
 		unsigned char m_StateFlags{ static_cast<unsigned char>(StateFlags::IsActiveLocalNextFrame) };
@@ -119,11 +118,9 @@ namespace leap
 		Transform* m_pTransform{};
 
 		std::vector<std::unique_ptr<GameObject>> m_pChildrenToAdd{};
-		std::vector<GameObject*> m_pNewestChildren{};
 		std::vector<std::unique_ptr<GameObject>> m_pChildren{};
 
 		std::vector<std::unique_ptr<Component>> m_pComponentsToAdd{};
-		std::vector<Component*> m_pNewestComponents{};
 		std::vector<std::unique_ptr<Component>> m_pComponents{};
 	};
 

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -14,7 +14,7 @@ namespace leap
 	class GameObject final
 	{
 	public:
-		GameObject(const std::string& name);
+		GameObject(const char* name);
 		~GameObject() = default;
 
 		GameObject(const GameObject& other) = delete;
@@ -25,14 +25,14 @@ namespace leap
 		void SetParent(GameObject* pParent);
 		GameObject* GetParent() const { return m_pParent; };
 
-		GameObject* CreateChild(const std::string& name);
+		GameObject* CreateChild(const char* name);
 		GameObject* GetChild(int index) const;
 		size_t GetChildCount() const { return m_pChildren.size(); };
 
-		void SetName(const std::string& name) { m_Name = name; }
+		void SetName(const char* name) { m_Name = name; }
 		const std::string& GetName() const { return m_Name; };
 
-		void SetTag(const std::string& tag) { m_Tag = tag; }
+		void SetTag(const char* tag) { m_Tag = tag; }
 		const std::string& GetTag() const { return m_Tag; }
 
 		void SetActive(bool isActive);
@@ -67,6 +67,8 @@ namespace leap
 		void OnGUI() const;
 		void OnDestroy() const;
 
+		const char* GetRawName() const { return m_Name; };
+
 		/// <summary>
 		/// Internally used to initialize gameobjects/components and update their active state
 		/// This will call the Awake, Start, OnEnable and OnDisable methods
@@ -90,8 +92,6 @@ namespace leap
 		void CheckDestroyFlag() const;
 		void UpdateCleanup();
 
-		std::string m_Name{};
-		std::string m_Tag{};
 
 		bool m_NextIsActiveLocal{ true };
 		bool m_IsActiveLocal{ false };
@@ -99,6 +99,8 @@ namespace leap
 		bool m_IsActiveWorld{ false };
 
 		bool m_IsMarkedDead{};
+		const char* m_Name{};
+		const char* m_Tag{};
 
 		GameObject* m_pParent{};
 		Transform* m_pTransform{};

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -36,10 +36,10 @@ namespace leap
 		const std::string& GetTag() const { return m_Tag; }
 
 		void SetActive(bool isActive);
-		bool IsActive() { return m_IsActiveWorld; }
+		bool IsActive() const;
 
 		void Destroy();
-		bool IsMarkedAsDead() const { return m_IsMarkedDead; };
+		bool IsMarkedAsDead() const;
 
 		template <class T>
 		T* AddComponent();
@@ -92,13 +92,26 @@ namespace leap
 		void CheckDestroyFlag() const;
 		void UpdateCleanup();
 
+		/// <summary>
+		/// These functions are internally used to 
+		/// change and check values of the m_StateFlags bitmask
+		/// </summary>
+		bool IsActiveLocalNextFrame() const;
+		bool IsActiveLocal() const;
+		void SetActiveLocal(bool isActive);
+		bool IsActiveWorld() const;
+		void SetActiveWorld(bool isActive);
 
-		bool m_NextIsActiveLocal{ true };
-		bool m_IsActiveLocal{ false };
+		enum class StateFlags : char
+		{
+			IsActiveLocalNextFrame = 1,
+			IsActiveLocal = 2,
+			IsActiveWorld = 4,
+			IsMarkedAsDead = 8
+		};
 
-		bool m_IsActiveWorld{ false };
+		unsigned char m_StateFlags{ static_cast<unsigned char>(StateFlags::IsActiveLocalNextFrame) };
 
-		bool m_IsMarkedDead{};
 		const char* m_Name{};
 		const char* m_Tag{};
 

--- a/LeapEngine/SceneGraph/Scene.cpp
+++ b/LeapEngine/SceneGraph/Scene.cpp
@@ -1,6 +1,6 @@
 #include "Scene.h"
 
-leap::Scene::Scene(const std::string& name)
+leap::Scene::Scene(const char* name)
 {
 	m_RootObject = std::make_unique<GameObject>(name);
 }
@@ -10,7 +10,7 @@ leap::Scene::~Scene()
 	m_RootObject->OnDestroy();
 }
 
-leap::GameObject* leap::Scene::CreateGameObject(const std::string& name) const
+leap::GameObject* leap::Scene::CreateGameObject(const char* name) const
 {
 	return m_RootObject->CreateChild(name);
 }
@@ -18,7 +18,7 @@ leap::GameObject* leap::Scene::CreateGameObject(const std::string& name) const
 void leap::Scene::RemoveAll()
 {
 	m_RootObject->OnDestroy();
-	std::string name = m_RootObject->GetName();
+	const char* name = m_RootObject->GetRawName();
 	m_RootObject.reset();
 	m_RootObject = std::make_unique<GameObject>(name);
 }

--- a/LeapEngine/SceneGraph/Scene.h
+++ b/LeapEngine/SceneGraph/Scene.h
@@ -9,7 +9,7 @@ namespace leap
 	class Scene final
 	{
 	public:
-		explicit Scene(const std::string& name);
+		explicit Scene(const char* name);
 		~Scene();
 
 		Scene(const Scene& other) = delete;
@@ -17,7 +17,7 @@ namespace leap
 		Scene& operator=(const Scene& other) = delete;
 		Scene& operator=(Scene&& other) = delete;
 
-		GameObject* CreateGameObject(const std::string& name) const;
+		GameObject* CreateGameObject(const char* name) const;
 		void RemoveAll();
 		GameObject* GetRootObject() const;
 

--- a/LeapEngine/SceneGraph/SceneManager.cpp
+++ b/LeapEngine/SceneGraph/SceneManager.cpp
@@ -10,7 +10,7 @@ leap::Scene* leap::SceneManager::GetActiveScene() const
 	return m_Scene.get();
 }
 
-void leap::SceneManager::AddScene(const std::string& name, const std::function<void(Scene&)>& load)
+void leap::SceneManager::AddScene(const char* name, const std::function<void(Scene&)>& load)
 {
 	m_Scenes.emplace_back(SceneData{ name, load });
 }
@@ -83,6 +83,6 @@ void leap::SceneManager::LoadInternalScene()
 	}
 	const auto& sceneData = m_Scenes[m_LoadScene];
 	m_LoadScene = -1;
-	m_Scene = std::make_unique<Scene>(sceneData.name);
+	m_Scene = std::make_unique<Scene>(sceneData.name.c_str());
 	sceneData.load(*m_Scene);
 }

--- a/LeapEngine/SceneGraph/SceneManager.h
+++ b/LeapEngine/SceneGraph/SceneManager.h
@@ -20,7 +20,7 @@ namespace leap
 		SceneManager& operator=(SceneManager&& other) = delete;
 
 		Scene* GetActiveScene() const;
-		void AddScene(const std::string& name, const std::function<void(Scene&)>& load);
+		void AddScene(const char* name, const std::function<void(Scene&)>& load);
 		void LoadScene(unsigned index);
 		void LoadScene(const std::string& name);
 
@@ -38,7 +38,7 @@ namespace leap
 
 		struct SceneData final
 		{
-			std::string name;
+			const std::string name;
 			std::function<void(Scene&)> load;
 		};
 		std::vector<SceneData> m_Scenes{};


### PR DESCRIPTION
1. I optimized the Gameobject class from 232 bytes to 136 bytes (-41%) by:

- Replacing strings with char*
- Replacing booleans with a bitmask
- Refactoring the initialization of new gameobjects so I could remove two std::vector variables

2. I cleaned up the Component class by merging 7 booleans into a bitmask

3. Fixed infinite FixedUpdate loop