### PR TITLE
Engine components now use transform events

### DIFF
--- a/LeapEngine/Components/Audio/AudioListener.cpp
+++ b/LeapEngine/Components/Audio/AudioListener.cpp
@@ -5,8 +5,18 @@
 
 #include "../Transform/Transform.h"
 
-void leap::AudioListener::Update()
+void leap::AudioListener::Notify()
 {
 	Transform* pTransform{ GetTransform() };
 	ServiceLocator::GetAudio().UpdateListener3D(pTransform->GetWorldPosition(), {}, pTransform->GetForward(), pTransform->GetUp());
+}
+
+void leap::AudioListener::Awake()
+{
+	GetTransform()->OnPositionChanged.AddListener(this);
+}
+
+void leap::AudioListener::OnDestroy()
+{
+	GetTransform()->OnPositionChanged.RemoveListener(this);
 }

--- a/LeapEngine/Components/Audio/AudioListener.h
+++ b/LeapEngine/Components/Audio/AudioListener.h
@@ -2,9 +2,11 @@
 
 #include "../Component.h"
 
+#include <Observer.h>
+
 namespace leap
 {
-	class AudioListener final : public Component
+	class AudioListener final : public Component, public Observer
 	{
 	public:
 		AudioListener() = default;
@@ -16,6 +18,8 @@ namespace leap
 		AudioListener& operator=(AudioListener&& other) = delete;
 
 	private:
-		virtual void Update() override;
+		virtual void Awake() override;
+		virtual void OnDestroy() override;
+		virtual void Notify() override;
 	};
 }

--- a/LeapEngine/Components/Audio/AudioSource.cpp
+++ b/LeapEngine/Components/Audio/AudioSource.cpp
@@ -123,9 +123,11 @@ bool leap::AudioSource::IsPlaying() const
 void leap::AudioSource::Awake()
 {
 	if (m_PlayOnAwake) Play();
+
+	GetTransform()->OnPositionChanged.AddListener(this);
 }
 
-void leap::AudioSource::Update()
+void leap::AudioSource::Notify()
 {
 	// Only update if there is a 3D sound playing
 	if (!IsPlaying() || !m_Is3DSound) return;
@@ -135,6 +137,8 @@ void leap::AudioSource::Update()
 
 void leap::AudioSource::OnDestroy()
 {
+	GetTransform()->OnPositionChanged.RemoveListener(this);
+
 	if (!IsPlaying()) return;
 
 	Stop();

--- a/LeapEngine/Components/Audio/AudioSource.h
+++ b/LeapEngine/Components/Audio/AudioSource.h
@@ -2,6 +2,8 @@
 
 #include "../Component.h"
 
+#include <Observer.h>
+
 #include <string>
 
 namespace leap
@@ -11,7 +13,7 @@ namespace leap
 		class IAudioClip;
 	}
 
-	class AudioSource final : public Component
+	class AudioSource final : public Component, public Observer
 	{
 	public:
 		AudioSource() = default;
@@ -42,7 +44,7 @@ namespace leap
 
 	private:
 		virtual void Awake() override;
-		virtual void Update() override;
+		virtual void Notify() override;
 		virtual void OnDestroy() override;
 
 		void Update2DVolume() const;

--- a/LeapEngine/Components/RenderComponents/CameraComponent.cpp
+++ b/LeapEngine/Components/RenderComponents/CameraComponent.cpp
@@ -9,6 +9,10 @@
 #include "../../GameContext/GameContext.h"
 #include "../../GameContext/Window.h"
 
+#include <functional>
+
+#include <Debug.h>
+
 leap::CameraComponent::CameraComponent()
 {
 	const auto window = GameContext::GetInstance().GetWindow();
@@ -27,12 +31,28 @@ void leap::CameraComponent::Notify(const glm::ivec2& data)
 	m_pCamera->SetAspectRatio(data);
 }
 
+void leap::CameraComponent::Awake()
+{
+	GetTransform()->OnPositionChanged.AddListener(this);
+	GetTransform()->OnRotationChanged.AddListener(this);
+
+	UpdateTransform();
+}
+
 void leap::CameraComponent::OnDestroy()
 {
 	GameContext::GetInstance().GetWindow()->RemoveListener(this);
+
+	GetTransform()->OnPositionChanged.RemoveListener(this);
+	GetTransform()->OnRotationChanged.RemoveListener(this);
 }
 
-void leap::CameraComponent::LateUpdate()
+void leap::CameraComponent::Notify()
+{
+	UpdateTransform();
+}
+
+void leap::CameraComponent::UpdateTransform() const
 {
 	// Only update the internal camera data if the camera is currently active
 	if (ServiceLocator::GetRenderer().GetCamera() != m_pCamera.get()) return;

--- a/LeapEngine/Components/RenderComponents/CameraComponent.h
+++ b/LeapEngine/Components/RenderComponents/CameraComponent.h
@@ -13,7 +13,7 @@ namespace leap
 		class Camera;
 	}
 
-	class CameraComponent final : public Component, TObserver<glm::ivec2>
+	class CameraComponent final : public Component, TObserver<glm::ivec2>, Observer
 	{
 	public:
 		CameraComponent();
@@ -29,11 +29,13 @@ namespace leap
 		void SetAsActiveCamera(bool active) const;
 		graphics::Camera* GetData() const { return m_pCamera.get(); }
 
-	protected:
-		virtual void OnDestroy() override;
-		virtual void LateUpdate() override;
-
 	private:
+		virtual void Awake() override;
+		virtual void OnDestroy() override;
+		virtual void Notify() override;
+
+		void UpdateTransform() const;
+
 		std::unique_ptr<graphics::Camera> m_pCamera{};
 	};
 }

--- a/LeapEngine/Components/RenderComponents/DirectionalLightComponent.cpp
+++ b/LeapEngine/Components/RenderComponents/DirectionalLightComponent.cpp
@@ -5,7 +5,25 @@
 #include "../../ServiceLocator/ServiceLocator.h"
 #include "Interfaces/IRenderer.h"
 
-void leap::DirectionalLightComponent::LateUpdate()
+void leap::DirectionalLightComponent::Awake()
+{
+	GetTransform()->OnPositionChanged.AddListener(this);
+	GetTransform()->OnRotationChanged.AddListener(this);
+	UpdateTransform();
+}
+
+void leap::DirectionalLightComponent::OnDestroy()
+{
+	GetTransform()->OnPositionChanged.RemoveListener(this);
+	GetTransform()->OnRotationChanged.RemoveListener(this);
+}
+
+void leap::DirectionalLightComponent::Notify()
+{
+	UpdateTransform();
+}
+
+void leap::DirectionalLightComponent::UpdateTransform() const
 {
 	ServiceLocator::GetRenderer().SetDirectionLight(
 		{

--- a/LeapEngine/Components/RenderComponents/DirectionalLightComponent.h
+++ b/LeapEngine/Components/RenderComponents/DirectionalLightComponent.h
@@ -2,9 +2,11 @@
 
 #include "../Component.h"
 
+#include <Observer.h>
+
 namespace leap
 {
-	class DirectionalLightComponent final : public Component
+	class DirectionalLightComponent final : public Component, public Observer
 	{
 	public:
 		DirectionalLightComponent() = default;
@@ -15,9 +17,11 @@ namespace leap
 		DirectionalLightComponent& operator=(const DirectionalLightComponent& other) = delete;
 		DirectionalLightComponent& operator=(DirectionalLightComponent&& other) = delete;
 
-	protected:
-		virtual void LateUpdate() override;
-
 	private:
+		virtual void Awake() override;
+		virtual void OnDestroy() override;
+		virtual void Notify() override;
+
+		void UpdateTransform() const;
 	};
 }


### PR DESCRIPTION
DirectionalLightComponent, CameraComponent, AudioSource and AudioListener now only send their transform to their respective engines when the Transform invokes an OnPositionChanged/OnRotationChanged event instead of every frame