### PR TITLE
Remove rtti from gameobject

### DIFF
--- a/LeapEngine/SceneGraph/GameObject.cpp
+++ b/LeapEngine/SceneGraph/GameObject.cpp
@@ -4,14 +4,11 @@
 
 #include "SceneManager.h"
 
+unsigned int leap::GameObject::m_TransformComponentID = leap::ReflectionUtils::GenerateTypenameHash<Transform>();
+
 leap::GameObject::GameObject(const char* name)
 	: m_Name{ name }
 {
-	if (TransformComponentID == -1)
-	{
-		TransformComponentID = GOutils::GenerateComponentID<Transform>();
-	}
-
 	m_pTransform = AddComponent<Transform>();
 }
 
@@ -114,9 +111,9 @@ void leap::GameObject::OnFrameStart()
 void leap::GameObject::MoveNewObjectsAndComponents()
 {	
 	// Move the components from the temp container to the default container
-	for (auto& pComponent : m_pComponentsToAdd)
+	for (auto& pComponent : m_ComponentsToAdd)
 	{
-		m_pComponents.emplace_back(std::move(pComponent));
+		m_Components.emplace_back(std::move(pComponent));
 	}
 
 	// Move the children from the temp container to the default container
@@ -126,7 +123,7 @@ void leap::GameObject::MoveNewObjectsAndComponents()
 	}
 
 	// Clear the temp folders
-	m_pComponentsToAdd.clear();
+	m_ComponentsToAdd.clear();
 	m_pChildrenToAdd.clear();
 
 	// Call MoveNewObjectsAndComponents on all children
@@ -139,7 +136,7 @@ void leap::GameObject::MoveNewObjectsAndComponents()
 void leap::GameObject::CallAwake() const
 {
 	// Call awake on the new components and children
-	for (const auto& [pComponent, ID] : m_pComponents)
+	for (const auto& [pComponent, id] : m_Components)
 	{
 		if (!pComponent->IsInitialized())
 		{
@@ -175,7 +172,7 @@ void leap::GameObject::ChangeActiveState()
 	}
 
 	// Update the active state of the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->ChangeActiveState();
+	for (const auto& [pComponent, id] : m_Components) pComponent->ChangeActiveState();
 
 	// Update the active state of the children
 	for (const auto& pChild : m_pChildren)
@@ -199,7 +196,7 @@ void leap::GameObject::SetWorldState(bool isActive)
 void leap::GameObject::CallStart() const
 {
 	// Call Start on the components if needed
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->TryCallStart();
+	for (const auto& [pComponent, id] : m_Components) pComponent->TryCallStart();
 
 	// Call OnEnable or OnDisable on the children
 	for (const auto& pChild : m_pChildren)
@@ -211,7 +208,7 @@ void leap::GameObject::CallStart() const
 void leap::GameObject::CallEnableAndDisable() const
 {
 	// Call OnEnable or OnDisable on the components if needed
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->TryCallEnableAndDisable();
+	for (const auto& [pComponent, id] : m_Components) pComponent->TryCallEnableAndDisable();
 
 	// Call OnEnable or OnDisable on the children
 	for (const auto& pChild : m_pChildren)
@@ -241,7 +238,7 @@ void leap::GameObject::CheckDestroyFlag() const
 	else
 	{
 		// Call OnDestroy on components if needed
-		for (const auto& [pComponent, ID] : m_pComponents)
+		for (const auto& [pComponent, id] : m_Components)
 		{
 			if (pComponent->IsMarkedAsDead()) pComponent->OnDestroy();
 		}
@@ -257,12 +254,12 @@ void leap::GameObject::CheckDestroyFlag() const
 void leap::GameObject::UpdateCleanup()
 {
 	// Remove all marked components
-	m_pComponents.erase(
+	m_Components.erase(
 		std::remove_if(
-			begin(m_pComponents), end(m_pComponents), 
+			begin(m_Components), end(m_Components), 
 			[](const ComponentInfo& CInfo) { return CInfo.pComponent->IsMarkedAsDead(); }
 		),
-		end(m_pComponents));
+		end(m_Components));
 
 	// Remove all children that are nullptr
 	m_pChildren.erase(
@@ -325,20 +322,20 @@ leap::Transform* leap::GameObject::GetTransform() const
 void leap::GameObject::OnEnable() const
 {
 	// Delegate OnEnable method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnEnable();
+	for (const auto& [pComponent, id] : m_Components) pComponent->OnEnable();
 }
 
 // This method is called per gameobject, so it shouldn't delegate the method to its children
 void leap::GameObject::OnDisable() const
 {
 	// Delegate OnDisable method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnDisable();
+	for (const auto& [pComponent, id] : m_Components) pComponent->OnDisable();
 }
 
 void leap::GameObject::Update() const
 {
 	// Delegate Update method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->Update();
+	for (const auto& [pComponent, id] : m_Components) pComponent->Update();
 
 	// Delegate Update method to the children
 	for (const auto& pChild : m_pChildren)
@@ -350,7 +347,7 @@ void leap::GameObject::Update() const
 void leap::GameObject::FixedUpdate() const
 {
 	// Delegate FixedUpdate method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->FixedUpdate();
+	for (const auto& [pComponent, id] : m_Components) pComponent->FixedUpdate();
 
 	// Delegate FixedUpdate method to the children
 	for (const auto& pChild : m_pChildren)
@@ -362,7 +359,7 @@ void leap::GameObject::FixedUpdate() const
 void leap::GameObject::LateUpdate() const
 {
 	// Delegate LateUpdate method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->LateUpdate();
+	for (const auto& [pComponent, id] : m_Components) pComponent->LateUpdate();
 
 	// Delegate LateUpdate method to the children
 	for (const auto& pChild : m_pChildren)
@@ -374,7 +371,7 @@ void leap::GameObject::LateUpdate() const
 void leap::GameObject::OnGUI() const
 {
 	// Delegate OnGUI method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnGUI();
+	for (const auto& [pComponent, id] : m_Components) pComponent->OnGUI();
 
 	// Delegate OnGUI method to the children
 	for (const auto& pChild : m_pChildren)
@@ -386,7 +383,7 @@ void leap::GameObject::OnGUI() const
 void leap::GameObject::OnDestroy() const
 {
 	// Delegate OnDestroy method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnDestroy();
+	for (const auto& [pComponent, id] : m_Components) pComponent->OnDestroy();
 
 	// Delegate OnDestroy method to the children
 	for (const auto& pChild : m_pChildren)
@@ -398,36 +395,36 @@ void leap::GameObject::OnDestroy() const
 void leap::GameObject::OnCollisionEnter(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnCollisionEnter method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnCollisionEnter(pCollider, pOther);
+	for (const auto& [pComponent, id] : m_Components) pComponent->OnCollisionEnter(pCollider, pOther);
 }
 
 void leap::GameObject::OnCollisionStay(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnCollisionStay method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnCollisionStay(pCollider, pOther);
+	for (const auto& [pComponent, id] : m_Components) pComponent->OnCollisionStay(pCollider, pOther);
 }
 
 void leap::GameObject::OnCollisionExit(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnCollisionExit method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnCollisionExit(pCollider, pOther);
+	for (const auto& [pComponent, id] : m_Components) pComponent->OnCollisionExit(pCollider, pOther);
 }
 
 void leap::GameObject::OnTriggerEnter(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnTriggerEnter method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnTriggerEnter(pCollider, pOther);
+	for (const auto& [pComponent, id] : m_Components) pComponent->OnTriggerEnter(pCollider, pOther);
 }
 
 void leap::GameObject::OnTriggerStay(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnTriggerStay method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnTriggerStay(pCollider, pOther);
+	for (const auto& [pComponent, id] : m_Components) pComponent->OnTriggerStay(pCollider, pOther);
 }
 
 void leap::GameObject::OnTriggerExit(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnTriggerExit method to the components
-	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnTriggerExit(pCollider, pOther);
+	for (const auto& [pComponent, id] : m_Components) pComponent->OnTriggerExit(pCollider, pOther);
 }
 #pragma endregion

--- a/LeapEngine/SceneGraph/GameObject.cpp
+++ b/LeapEngine/SceneGraph/GameObject.cpp
@@ -139,7 +139,7 @@ void leap::GameObject::MoveNewObjectsAndComponents()
 void leap::GameObject::CallAwake() const
 {
 	// Call awake on the new components and children
-	for (const auto& pComponent : m_pComponents)
+	for (const auto& [pComponent, ID] : m_pComponents)
 	{
 		if (!pComponent->IsInitialized())
 		{
@@ -175,7 +175,7 @@ void leap::GameObject::ChangeActiveState()
 	}
 
 	// Update the active state of the components
-	for (const auto& pComponent : m_pComponents) pComponent->ChangeActiveState();
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->ChangeActiveState();
 
 	// Update the active state of the children
 	for (const auto& pChild : m_pChildren)
@@ -199,7 +199,7 @@ void leap::GameObject::SetWorldState(bool isActive)
 void leap::GameObject::CallStart() const
 {
 	// Call Start on the components if needed
-	for (const auto& pComponent : m_pComponents) pComponent->TryCallStart();
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->TryCallStart();
 
 	// Call OnEnable or OnDisable on the children
 	for (const auto& pChild : m_pChildren)
@@ -211,7 +211,7 @@ void leap::GameObject::CallStart() const
 void leap::GameObject::CallEnableAndDisable() const
 {
 	// Call OnEnable or OnDisable on the components if needed
-	for (const auto& pComponent : m_pComponents) pComponent->TryCallEnableAndDisable();
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->TryCallEnableAndDisable();
 
 	// Call OnEnable or OnDisable on the children
 	for (const auto& pChild : m_pChildren)
@@ -241,7 +241,7 @@ void leap::GameObject::CheckDestroyFlag() const
 	else
 	{
 		// Call OnDestroy on components if needed
-		for (const auto& pComponent : m_pComponents)
+		for (const auto& [pComponent, ID] : m_pComponents)
 		{
 			if (pComponent->IsMarkedAsDead()) pComponent->OnDestroy();
 		}
@@ -260,7 +260,7 @@ void leap::GameObject::UpdateCleanup()
 	m_pComponents.erase(
 		std::remove_if(
 			begin(m_pComponents), end(m_pComponents), 
-			[](const auto& pComponent) { return pComponent->IsMarkedAsDead(); }
+			[](const ComponentInfo& CInfo) { return CInfo.pComponent->IsMarkedAsDead(); }
 		),
 		end(m_pComponents));
 
@@ -325,20 +325,20 @@ leap::Transform* leap::GameObject::GetTransform() const
 void leap::GameObject::OnEnable() const
 {
 	// Delegate OnEnable method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->OnEnable();
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnEnable();
 }
 
 // This method is called per gameobject, so it shouldn't delegate the method to its children
 void leap::GameObject::OnDisable() const
 {
 	// Delegate OnDisable method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->OnDisable();
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnDisable();
 }
 
 void leap::GameObject::Update() const
 {
 	// Delegate Update method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->Update();
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->Update();
 
 	// Delegate Update method to the children
 	for (const auto& pChild : m_pChildren)
@@ -350,7 +350,7 @@ void leap::GameObject::Update() const
 void leap::GameObject::FixedUpdate() const
 {
 	// Delegate FixedUpdate method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->FixedUpdate();
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->FixedUpdate();
 
 	// Delegate FixedUpdate method to the children
 	for (const auto& pChild : m_pChildren)
@@ -362,7 +362,7 @@ void leap::GameObject::FixedUpdate() const
 void leap::GameObject::LateUpdate() const
 {
 	// Delegate LateUpdate method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->LateUpdate();
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->LateUpdate();
 
 	// Delegate LateUpdate method to the children
 	for (const auto& pChild : m_pChildren)
@@ -374,7 +374,7 @@ void leap::GameObject::LateUpdate() const
 void leap::GameObject::OnGUI() const
 {
 	// Delegate OnGUI method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->OnGUI();
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnGUI();
 
 	// Delegate OnGUI method to the children
 	for (const auto& pChild : m_pChildren)
@@ -386,7 +386,7 @@ void leap::GameObject::OnGUI() const
 void leap::GameObject::OnDestroy() const
 {
 	// Delegate OnDestroy method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->OnDestroy();
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnDestroy();
 
 	// Delegate OnDestroy method to the children
 	for (const auto& pChild : m_pChildren)
@@ -398,36 +398,36 @@ void leap::GameObject::OnDestroy() const
 void leap::GameObject::OnCollisionEnter(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnCollisionEnter method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->OnCollisionEnter(pCollider, pOther);
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnCollisionEnter(pCollider, pOther);
 }
 
 void leap::GameObject::OnCollisionStay(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnCollisionStay method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->OnCollisionStay(pCollider, pOther);
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnCollisionStay(pCollider, pOther);
 }
 
 void leap::GameObject::OnCollisionExit(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnCollisionExit method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->OnCollisionExit(pCollider, pOther);
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnCollisionExit(pCollider, pOther);
 }
 
 void leap::GameObject::OnTriggerEnter(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnTriggerEnter method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->OnTriggerEnter(pCollider, pOther);
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnTriggerEnter(pCollider, pOther);
 }
 
 void leap::GameObject::OnTriggerStay(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnTriggerStay method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->OnTriggerStay(pCollider, pOther);
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnTriggerStay(pCollider, pOther);
 }
 
 void leap::GameObject::OnTriggerExit(Collider* pCollider, Collider* pOther) const
 {
 	// Delegate OnTriggerExit method to the components
-	for (const auto& pComponent : m_pComponents) pComponent->OnTriggerExit(pCollider, pOther);
+	for (const auto& [pComponent, ID] : m_pComponents) pComponent->OnTriggerExit(pCollider, pOther);
 }
 #pragma endregion

--- a/LeapEngine/SceneGraph/GameObject.cpp
+++ b/LeapEngine/SceneGraph/GameObject.cpp
@@ -2,7 +2,6 @@
 
 #include "../Components/Transform/Transform.h"
 
-#include "Debug.h"
 #include "SceneManager.h"
 
 leap::GameObject::GameObject(const char* name)

--- a/LeapEngine/SceneGraph/GameObject.cpp
+++ b/LeapEngine/SceneGraph/GameObject.cpp
@@ -7,6 +7,11 @@
 leap::GameObject::GameObject(const char* name)
 	: m_Name{ name }
 {
+	if (TransformComponentID == -1)
+	{
+		TransformComponentID = GOutils::GenerateComponentID<Transform>();
+	}
+
 	m_pTransform = AddComponent<Transform>();
 }
 

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -222,7 +222,7 @@ namespace leap
 	template<class T>
 	inline void GameObject::RemoveComponent()
 	{
-		static_assert(std::is_base_of<Component, T>::value, "T needs to be derived from the Component class");
+		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
 		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
 		if (ComponentID == TransformComponentID)
@@ -237,13 +237,18 @@ namespace leap
 	template<class T>
 	inline void GameObject::RemoveComponent(T* pComponent)
 	{
-		static_assert(std::is_base_of<Component, T>::value, "T needs to be derived from the Component class");
+		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
-		// TODO: Don't let the user destroy the transform component
+		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
+		if (ComponentID == TransformComponentID)
+		{
+			Debug::LogError("LeapEngine Error: GameObject::RemoveComponent() > Cannot manually remove Transform");
+			return;
+		}
 
 		// Don't try to remove a component that is not on this gameobject
-		if (std::find_if(begin(m_pComponents), end(m_pComponents), [](const auto& pComponent)
-			{ return pComponent.get() == pComponent; }) == end(m_pComponents))
+		if (std::find_if(begin(m_pComponents), end(m_pComponents), [](const ComponentInfo& CInfo)
+			{ return CInfo.pComponent.get() == pComponent; }) == end(m_pComponents))
 		{
 			return;
 		}

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -2,7 +2,7 @@
 
 #include "../Components/Component.h"
 #include "Debug.h"
-#include "../Utils/ReflectionUtils.h"
+#include "ReflectionUtils.h"
 
 #include <string>
 #include <memory>

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -147,6 +147,8 @@ namespace leap
 	{
 		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
+		// TODO: Cant have multiple transform components, but should have multiple of other components
+
 		const auto IsComponentIDPresent = [](const std::vector<ComponentInfo>& Components, const int ID)->bool
 			{
 				return std::find_if(Components.cbegin(), Components.cend(), [ID](const ComponentInfo& CInfo)->bool
@@ -176,13 +178,20 @@ namespace leap
 	template<class T>
 	inline T* GameObject::GetComponent() const
 	{
-		static_assert(std::is_base_of<Component, T>::value, "T needs to be derived from the Component class");
+		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
-		const auto iterator{ std::find_if(begin(m_pComponents), end(m_pComponents), [](const auto& pComponent) { return dynamic_cast<T*>(pComponent.get()) != nullptr; }) };
+		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
 
-		if (iterator == end(m_pComponents)) return nullptr;
+		const auto iterator
+		{
+			std::find_if(m_pComponents.begin(), m_pComponents.end(),
+			[ComponentID](const ComponentInfo& CInfo)
+			{
+				return ComponentID == CInfo.ID;
+			})
+		};
 
-		return static_cast<T*>(iterator->get());
+		return iterator != m_pComponents.end() ? iterator->pComponent.get() : nullptr;
 	}
 
 	template<class T>

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -189,13 +189,17 @@ namespace leap
 	template<class T>
 	inline std::vector<T*> GameObject::GetComponents() const
 	{
-		static_assert(std::is_base_of<Component, T>::value, "T needs to be derived from the Component class");
+		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
 		std::vector<T*> pComponents{};
+		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
 
-		for (const auto& pComponent : m_pComponents)
+		for (const ComponentInfo& CInfo : m_pComponents)
 		{
-			if (dynamic_cast<T*>(pComponent.get()) != nullptr) pComponents.emplace_back(static_cast<T*>(pComponent.get()));
+			if (ComponentID == CInfo.ID)
+			{
+				pComponents.push_back(CInfo.pComponent.get());
+			}
 		}
 
 		return pComponents;

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -158,6 +158,8 @@ namespace leap
 
 		ComponentInfo& CInfo{ m_pComponentsToAdd.emplace_back(std::make_unique<T>(), ComponentID) };
 
+		CInfo.pComponent->SetOwner(this);
+
 		return static_cast<T*>(CInfo.pComponent.get());
 	}
 

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -20,10 +20,10 @@ namespace leap
 		struct ComponentInfo
 		{
 			std::unique_ptr<Component> pComponent;
-			int ID;
+			uint32_t ID;
 		};
 
-		inline static int TransformComponentID{ -1 };
+		inline static uint32_t TransformComponentID{ static_cast<uint32_t>(-1) };
 
 	public:
 		GameObject(const char* name);
@@ -149,7 +149,7 @@ namespace leap
 	{
 		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
-		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
+		constexpr uint32_t ComponentID{ GOutils::GenerateComponentID<T>() };
 		if (ComponentID == TransformComponentID && HasComponent<T>())
 		{
 			Debug::LogError("LeapEngine Error: GameObject::AddComponent() > Can't add multiple Transforms");
@@ -158,7 +158,7 @@ namespace leap
 
 		ComponentInfo& CInfo{ m_pComponentsToAdd.emplace_back(std::make_unique<T>(), ComponentID) };
 
-		return CInfo.pComponent.get();
+		return static_cast<T*>(CInfo.pComponent.get());
 	}
 
 	template<class T>
@@ -172,7 +172,7 @@ namespace leap
 	{
 		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
-		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
+		constexpr uint32_t ComponentID{ GOutils::GenerateComponentID<T>() };
 
 		const auto iterator
 		{
@@ -183,7 +183,7 @@ namespace leap
 			})
 		};
 
-		return iterator != m_pComponents.end() ? iterator->pComponent.get() : nullptr;
+		return iterator != m_pComponents.end() ? static_cast<T*>(iterator->pComponent.get()) : nullptr;
 	}
 
 	template<class T>
@@ -192,13 +192,13 @@ namespace leap
 		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
 		std::vector<T*> pComponents{};
-		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
+		constexpr uint32_t ComponentID{ GOutils::GenerateComponentID<T>() };
 
 		for (const ComponentInfo& CInfo : m_pComponents)
 		{
 			if (ComponentID == CInfo.ID)
 			{
-				pComponents.push_back(CInfo.pComponent.get());
+				pComponents.push_back(static_cast<T*>(CInfo.pComponent.get()));
 			}
 		}
 
@@ -224,7 +224,7 @@ namespace leap
 	{
 		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
-		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
+		constexpr uint32_t ComponentID{ GOutils::GenerateComponentID<T>() };
 		if (ComponentID == TransformComponentID)
 		{
 			Debug::LogError("LeapEngine Error: GameObject::RemoveComponent() > Cannot manually remove Transform");
@@ -239,7 +239,7 @@ namespace leap
 	{
 		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
-		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
+		constexpr uint32_t ComponentID{ GOutils::GenerateComponentID<T>() };
 		if (ComponentID == TransformComponentID)
 		{
 			Debug::LogError("LeapEngine Error: GameObject::RemoveComponent() > Cannot manually remove Transform");

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -23,6 +23,8 @@ namespace leap
 			int ID;
 		};
 
+		inline static int TransformComponentID{ -1 };
+
 	public:
 		GameObject(const char* name);
 		~GameObject() = default;
@@ -147,20 +149,10 @@ namespace leap
 	{
 		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
-		// TODO: Cant have multiple transform components, but should have multiple of other components
-
-		const auto IsComponentIDPresent = [](const std::vector<ComponentInfo>& Components, const int ID)->bool
-			{
-				return std::find_if(Components.cbegin(), Components.cend(), [ID](const ComponentInfo& CInfo)->bool
-					{
-						return ID == CInfo.ID;
-					}) != Components.cend();
-			};
-
 		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
-		if (IsComponentIDPresent(m_pComponents, ComponentID) || IsComponentIDPresent(m_pComponentsToAdd, ComponentID))
+		if (ComponentID == TransformComponentID && HasComponent<T>())
 		{
-			Debug::LogError("LeapEngine Error: GameObject::AddComponent() > Can't add identical component types");
+			Debug::LogError("LeapEngine Error: GameObject::AddComponent() > Can't add multiple Transforms");
 			return nullptr;
 		}
 

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -208,7 +208,7 @@ namespace leap
 	template<class T>
 	inline T* GameObject::GetComponentInParent() const
 	{
-		static_assert(std::is_base_of<Component, T>::value, "T needs to be derived from the Component class");
+		static_assert(std::is_base_of_v<Component, T>, "T needs to be derived from the Component class");
 
 		GameObject* pParent{ GetParent() };
 		if (pParent == nullptr) return nullptr;

--- a/LeapEngine/SceneGraph/GameObject.h
+++ b/LeapEngine/SceneGraph/GameObject.h
@@ -224,7 +224,12 @@ namespace leap
 	{
 		static_assert(std::is_base_of<Component, T>::value, "T needs to be derived from the Component class");
 
-		// TODO: Don't let the user destroy the transform component
+		constexpr int ComponentID{ GOutils::GenerateComponentID<T>() };
+		if (ComponentID == TransformComponentID)
+		{
+			Debug::LogError("LeapEngine Error: GameObject::RemoveComponent() > Cannot manually remove Transform");
+			return;
+		}
 
 		GetComponent<T>()->Destroy();
 	}

--- a/LeapEngine/SceneGraph/GameObjectUtils.h
+++ b/LeapEngine/SceneGraph/GameObjectUtils.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <algorithm>
 #include <string_view>
+
+#ifdef max
+#undef max
+#endif
 
 namespace leap::GOutils
 {
@@ -15,11 +20,6 @@ namespace leap::GOutils
 			return __PRETTY_FUNCTION__;
 			#endif
 		}
-
-		constexpr size_t Max(const size_t A, const size_t B)
-		{
-			return A < B ? B : A;
-		}
 	}
 
 	// Reference for TypeName: https://stackoverflow.com/questions/35941045/can-i-obtain-c-type-names-in-a-constexpr-way
@@ -30,7 +30,7 @@ namespace leap::GOutils
 
 		constexpr size_t endOfType{ wrappedName.find_last_of('>') };
 		// I would use std::max, but it doesn't work for some inexplicable reason
-		constexpr size_t beginOfType{ Detail::Max(wrappedName.find_last_of(' '), wrappedName.find_last_of('<')) };
+		constexpr size_t beginOfType{ std::max(wrappedName.find_last_of(' '), wrappedName.find_last_of('<')) };
 
 		return wrappedName.substr(beginOfType + 1, endOfType - beginOfType - 1);
 	}

--- a/LeapEngine/SceneGraph/GameObjectUtils.h
+++ b/LeapEngine/SceneGraph/GameObjectUtils.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <algorithm>
 #include <string_view>
 
 namespace leap::GOutils
 {
-	namespace Detail
+	namespace /*Detail*/
 	{
 		template<typename T>
 		constexpr std::string_view WrappedTypename()
@@ -21,24 +22,32 @@ namespace leap::GOutils
 	template <typename T>
 	constexpr std::string_view ConstexprTypeName()
 	{
-		constexpr std::string_view wrappedName(Detail::WrappedTypeName<T>());
+		constexpr std::string_view wrappedName{ WrappedTypename<T>() };
 
 		constexpr size_t endOfType{ wrappedName.find_last_of('>') };
-		constexpr size_t beginOfType{ Math::Max(wrappedName.find_last_of(' '), wrappedName.find_last_of('<')) };
+		constexpr size_t beginOfType{ std::max(wrappedName.find_last_of(' '), wrappedName.find_last_of('<')) };
 
 		return wrappedName.substr(beginOfType + 1, endOfType - beginOfType - 1);
 	}
 
-	constexpr int ConstexprStringHash(const std::string_view String)
+	// Reference: https://www.partow.net/programming/hashfunctions/index.html#AvailableHashFunctions
+	constexpr uint32_t ConstexprStringHash(const char* str, uint32_t length)
 	{
-		return std::hash<std::string_view>{}(String);
+		uint32_t hash = 1315423911;
+
+		for (uint32_t i = 0; i < length; ++str, ++i)
+		{
+			hash ^= ((hash << 5) + (*str) + (hash >> 2));
+		}
+
+		return hash;
 	}
 
 	template<typename T>
-	constexpr int GenerateComponentID()
+	constexpr uint32_t GenerateComponentID()
 	{
-		constexpr std::string_view typeName(ConstexprTypeName<T>());
+		constexpr std::string_view Typename(ConstexprTypeName<T>());
 
-		return ConstexprStringHash(String);
+		return ConstexprStringHash(Typename.data(), static_cast<uint32_t>(Typename.size()));
 	}
 }

--- a/LeapEngine/SceneGraph/GameObjectUtils.h
+++ b/LeapEngine/SceneGraph/GameObjectUtils.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <string_view>
+
+namespace leap::GOutils
+{
+	namespace Detail
+	{
+		template<typename T>
+		constexpr std::string_view WrappedTypename()
+		{
+			#if _MSC_VER
+			return __FUNCSIG__;
+			#else // GCC and Clang use __PRETTY_FUNCTION__
+			return __PRETTY_FUNCTION__;
+			#endif
+		}
+	}
+
+	// Reference for TypeName: https://stackoverflow.com/questions/35941045/can-i-obtain-c-type-names-in-a-constexpr-way
+	template <typename T>
+	constexpr std::string_view ConstexprTypeName()
+	{
+		constexpr std::string_view wrappedName(Detail::WrappedTypeName<T>());
+
+		constexpr size_t endOfType{ wrappedName.find_last_of('>') };
+		constexpr size_t beginOfType{ Math::Max(wrappedName.find_last_of(' '), wrappedName.find_last_of('<')) };
+
+		return wrappedName.substr(beginOfType + 1, endOfType - beginOfType - 1);
+	}
+
+	constexpr int ConstexprStringHash(const std::string_view String)
+	{
+		return std::hash<std::string_view>{}(String);
+	}
+
+	template<typename T>
+	constexpr int GenerateComponentID()
+	{
+		constexpr std::string_view typeName(ConstexprTypeName<T>());
+
+		return ConstexprStringHash(String);
+	}
+}

--- a/LeapEngine/SceneGraph/GameObjectUtils.h
+++ b/LeapEngine/SceneGraph/GameObjectUtils.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <algorithm>
 #include <string_view>
 
 namespace leap::GOutils
 {
-	namespace /*Detail*/
+	namespace Detail
 	{
 		template<typename T>
 		constexpr std::string_view WrappedTypename()
@@ -16,16 +15,22 @@ namespace leap::GOutils
 			return __PRETTY_FUNCTION__;
 			#endif
 		}
+
+		constexpr size_t Max(const size_t A, const size_t B)
+		{
+			return A < B ? B : A;
+		}
 	}
 
 	// Reference for TypeName: https://stackoverflow.com/questions/35941045/can-i-obtain-c-type-names-in-a-constexpr-way
 	template <typename T>
 	constexpr std::string_view ConstexprTypeName()
 	{
-		constexpr std::string_view wrappedName{ WrappedTypename<T>() };
+		constexpr std::string_view wrappedName{ Detail::WrappedTypename<T>() };
 
 		constexpr size_t endOfType{ wrappedName.find_last_of('>') };
-		constexpr size_t beginOfType{ std::max(wrappedName.find_last_of(' '), wrappedName.find_last_of('<')) };
+		// I would use std::max, but it doesn't work for some inexplicable reason
+		constexpr size_t beginOfType{ Detail::Max(wrappedName.find_last_of(' '), wrappedName.find_last_of('<')) };
 
 		return wrappedName.substr(beginOfType + 1, endOfType - beginOfType - 1);
 	}

--- a/Utils/ReflectionUtils.h
+++ b/Utils/ReflectionUtils.h
@@ -7,7 +7,7 @@
 #undef max
 #endif
 
-namespace leap::GOutils
+namespace leap::ReflectionUtils
 {
 	namespace Detail
 	{
@@ -36,11 +36,11 @@ namespace leap::GOutils
 	}
 
 	// Reference: https://www.partow.net/programming/hashfunctions/index.html#AvailableHashFunctions
-	constexpr uint32_t ConstexprStringHash(const char* str, uint32_t length)
+	constexpr unsigned int ConstexprStringHash(const char* str, unsigned int length)
 	{
-		uint32_t hash = 1315423911;
+		unsigned int hash = 1315423911;
 
-		for (uint32_t i = 0; i < length; ++str, ++i)
+		for (unsigned int i = 0; i < length; ++str, ++i)
 		{
 			hash ^= ((hash << 5) + (*str) + (hash >> 2));
 		}
@@ -49,10 +49,10 @@ namespace leap::GOutils
 	}
 
 	template<typename T>
-	constexpr uint32_t GenerateComponentID()
+	constexpr unsigned int GenerateTypenameHash()
 	{
 		constexpr std::string_view Typename(ConstexprTypeName<T>());
 
-		return ConstexprStringHash(Typename.data(), static_cast<uint32_t>(Typename.size()));
+		return ConstexprStringHash(Typename.data(), static_cast<unsigned int>(Typename.size()));
 	}
 }


### PR DESCRIPTION
Removes the need for `dynamic_cast` to and from `Component` and adds certain missing features, such as only 1 allowed `Transform`